### PR TITLE
Changed git clone to correct url

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ format lookups and preventing further exploitation of this attack
 
 1. Download this report and build it 
 
-   1.1 `git clone https://github.com/cybereason/Logout4Shell.ssh`
+   1.1 `git clone https://github.com/cybereason/Logout4Shell.git`
 
    1.2 build it - `mvn package`
 


### PR DESCRIPTION
Currently the readme has an incorrect git clone url, the url should end in .git instead of .ssh. This PR fixes that. 

Fixes #4 